### PR TITLE
Implement serverside bypass for signature checking by using a system chat packet

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -83,7 +83,7 @@ curseforge {
 
 modrinth {
     token = findProperty('modrinthKey') ?: 'none'
-    projectId = "qQyHxfxd"
+    projectId = "no-chat-reports"
     versionNumber = project.mod_version
 	versionName = "No Chat Reports Fabric-" + project.mod_version
     versionType = "release"
@@ -94,7 +94,7 @@ modrinth {
 	
 	dependencies {
 		// The scope can be `required`, `optional`, or `incompatible`
-		required.project "P7dR8mSH"
+		required.project "fabric-api"
     }
 	
 	//syncBodyFrom = rootProject.file("docs/README.md").text

--- a/src/main/java/com/aizistral/nochatreports/handlers/NoReportsConfig.java
+++ b/src/main/java/com/aizistral/nochatreports/handlers/NoReportsConfig.java
@@ -1,24 +1,21 @@
 package com.aizistral.nochatreports.handlers;
 
-import java.io.File;
-import java.io.FileReader;
-import java.io.FileWriter;
-import java.io.IOException;
-import java.util.Optional;
-
-import javax.annotation.Nullable;
-
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-
 import net.fabricmc.loader.api.FabricLoader;
-import net.minecraft.client.Minecraft;
+
+import javax.annotation.Nullable;
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 public class NoReportsConfig {
-	private static final File CONFIG_FOLDER = FabricLoader.getInstance().getConfigDir().toFile();
-	private static final File CONFIG_FILE = new File(CONFIG_FOLDER, "NoChatReports.json");
+	private static final Path CONFIG_FILE = FabricLoader.getInstance().getConfigDir().resolve("NoChatReports.json");
+	private static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
 	private static NoReportsConfig INSTANCE;
-	private boolean demandOnClient, demandOnServer;
+	private boolean demandOnClient, demandOnServer, convertToGameMessage;
 
 	public static void loadConfig() {
 		INSTANCE = readFile();
@@ -33,21 +30,19 @@ public class NoReportsConfig {
 
 	@Nullable
 	private static NoReportsConfig readFile() {
-		if (!CONFIG_FILE.exists() || !CONFIG_FILE.isFile())
+		if (!Files.isRegularFile(CONFIG_FILE))
 			return null;
 
-		try (FileReader reader = new FileReader(CONFIG_FILE)) {
-			NoReportsConfig transience = new Gson().fromJson(reader, NoReportsConfig.class);
-			return transience;
+		try (BufferedReader reader = Files.newBufferedReader(CONFIG_FILE)) {
+			return GSON.fromJson(reader, NoReportsConfig.class);
 		} catch (IOException ex) {
 			throw new RuntimeException(ex);
 		}
 	}
 
 	private static void writeFile(NoReportsConfig instance) {
-		try (FileWriter writer = new FileWriter(CONFIG_FILE)) {
-			Gson gson = new GsonBuilder().setPrettyPrinting().create();
-			gson.toJson(instance, writer);
+		try (BufferedWriter writer = Files.newBufferedWriter(CONFIG_FILE)) {
+			GSON.toJson(instance, writer);
 		} catch (Exception ex) {
 			throw new RuntimeException(ex);
 		}
@@ -59,6 +54,10 @@ public class NoReportsConfig {
 
 	public static boolean demandsOnServer() {
 		return INSTANCE.demandOnServer;
+	}
+
+	public static boolean convertsToGameMessage() {
+		return INSTANCE.convertToGameMessage;
 	}
 
 }

--- a/src/main/java/com/aizistral/nochatreports/handlers/NoReportsConfig.java
+++ b/src/main/java/com/aizistral/nochatreports/handlers/NoReportsConfig.java
@@ -1,15 +1,17 @@
 package com.aizistral.nochatreports.handlers;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import net.fabricmc.loader.api.FabricLoader;
-
-import javax.annotation.Nullable;
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+
+import javax.annotation.Nullable;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+
+import net.fabricmc.loader.api.FabricLoader;
 
 public class NoReportsConfig {
 	private static final Path CONFIG_FILE = FabricLoader.getInstance().getConfigDir().resolve("NoChatReports.json");

--- a/src/main/java/com/aizistral/nochatreports/mixins/MixinOptions.java
+++ b/src/main/java/com/aizistral/nochatreports/mixins/MixinOptions.java
@@ -25,9 +25,8 @@ public class MixinOptions {
 		if (this.alternativeOption == null) {
 			this.alternativeOption = new OptionInstance<>("options.onlyShowSecureChat",
 					OptionInstance.cachedConstantTooltip(Component.translatable("gui.nochatreport.secureChat")),
-					(component, value) -> {
-						return value ? CommonComponents.OPTION_ON : CommonComponents.OPTION_OFF;
-					}, new OptionInstance.Enum<>(ImmutableList.of(Boolean.FALSE), Codec.BOOL), false, (value) -> {});
+					(component, value) -> value ? CommonComponents.OPTION_ON : CommonComponents.OPTION_OFF,
+					new OptionInstance.Enum<>(ImmutableList.of(Boolean.FALSE), Codec.BOOL), false, (value) -> {});
 		}
 
 		return this.alternativeOption;

--- a/src/main/java/com/aizistral/nochatreports/mixins/MixinServerPlayer.java
+++ b/src/main/java/com/aizistral/nochatreports/mixins/MixinServerPlayer.java
@@ -1,0 +1,39 @@
+package com.aizistral.nochatreports.mixins;
+
+import com.aizistral.nochatreports.NoChatReports;
+import com.aizistral.nochatreports.handlers.NoReportsConfig;
+import net.minecraft.network.chat.ChatDecoration;
+import net.minecraft.network.chat.ChatType;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.protocol.Packet;
+import net.minecraft.network.protocol.game.ClientboundPlayerChatPacket;
+import net.minecraft.network.protocol.game.ClientboundSystemChatPacket;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.server.network.ServerGamePacketListenerImpl;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(ServerPlayer.class)
+public abstract class MixinServerPlayer {
+
+    @Shadow
+    protected abstract int resolveChatTypeId(ResourceKey<ChatType> resourceKey);
+
+    @Redirect(method = "sendChatMessage(Lnet/minecraft/network/chat/PlayerChatMessage;Lnet/minecraft/network/chat/ChatSender;Lnet/minecraft/resources/ResourceKey;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/network/ServerGamePacketListenerImpl;send(Lnet/minecraft/network/protocol/Packet;)V"))
+    void extractChatMessage(ServerGamePacketListenerImpl listener, Packet<?> packet) {
+        if (NoReportsConfig.convertsToGameMessage()) {
+            if (packet instanceof ClientboundPlayerChatPacket chat) {
+                Component component = chat.unsignedContent().orElse(chat.signedContent());
+                component = ChatDecoration.withSender("chat.type.text").decorate(component, chat.sender());
+                packet = new ClientboundSystemChatPacket(component, resolveChatTypeId(ChatType.SYSTEM));
+            } else {
+                NoChatReports.LOGGER.warn("Unexpected packet type in sendChatMessage, skipping");
+            }
+        }
+        listener.send(packet);
+    }
+
+}

--- a/src/main/java/com/aizistral/nochatreports/mixins/MixinServerPlayer.java
+++ b/src/main/java/com/aizistral/nochatreports/mixins/MixinServerPlayer.java
@@ -19,21 +19,21 @@ import org.spongepowered.asm.mixin.injection.Redirect;
 @Mixin(ServerPlayer.class)
 public abstract class MixinServerPlayer {
 
-    @Shadow
-    protected abstract int resolveChatTypeId(ResourceKey<ChatType> resourceKey);
+	@Shadow
+	protected abstract int resolveChatTypeId(ResourceKey<ChatType> resourceKey);
 
-    @Redirect(method = "sendChatMessage(Lnet/minecraft/network/chat/PlayerChatMessage;Lnet/minecraft/network/chat/ChatSender;Lnet/minecraft/resources/ResourceKey;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/network/ServerGamePacketListenerImpl;send(Lnet/minecraft/network/protocol/Packet;)V"))
-    void extractChatMessage(ServerGamePacketListenerImpl listener, Packet<?> packet) {
-        if (NoReportsConfig.convertsToGameMessage()) {
-            if (packet instanceof ClientboundPlayerChatPacket chat) {
-                Component component = chat.unsignedContent().orElse(chat.signedContent());
-                component = ChatDecoration.withSender("chat.type.text").decorate(component, chat.sender());
-                packet = new ClientboundSystemChatPacket(component, resolveChatTypeId(ChatType.SYSTEM));
-            } else {
-                NoChatReports.LOGGER.warn("Unexpected packet type in sendChatMessage, skipping");
-            }
-        }
-        listener.send(packet);
-    }
+	@Redirect(method = "sendChatMessage(Lnet/minecraft/network/chat/PlayerChatMessage;Lnet/minecraft/network/chat/ChatSender;Lnet/minecraft/resources/ResourceKey;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/network/ServerGamePacketListenerImpl;send(Lnet/minecraft/network/protocol/Packet;)V"))
+	void extractChatMessage(ServerGamePacketListenerImpl listener, Packet<?> packet) {
+		if (NoReportsConfig.convertsToGameMessage()) {
+			if (packet instanceof ClientboundPlayerChatPacket chat) {
+				Component component = chat.unsignedContent().orElse(chat.signedContent());
+				component = ChatDecoration.withSender("chat.type.text").decorate(component, chat.sender());
+				packet = new ClientboundSystemChatPacket(component, resolveChatTypeId(ChatType.SYSTEM));
+			} else {
+				NoChatReports.LOGGER.warn("Unexpected packet type in sendChatMessage, skipping");
+			}
+		}
+		listener.send(packet);
+	}
 
 }

--- a/src/main/resources/nochatreports.mixins.json
+++ b/src/main/resources/nochatreports.mixins.json
@@ -7,7 +7,8 @@
   "verbose": true,
   "mixins": [
 	"MixinPlayer",
-	"MixinServerboundChatPacket"
+	"MixinServerboundChatPacket",
+	"MixinServerPlayer"
   ],
   "client": [
 	"MixinLocalPlayer",


### PR DESCRIPTION
Formatting is applied to the text serverside so the clientside appearance is the same as vanilla.
This is disabled by default through the convertToGameMessage config option since it could confuse clientside modifications that apply additional formatting to chat messages (such as displaying player heads next to them)
In addition to this change, I have made the following changes to the code:
- The modrinth block in build.gradle now utilizes minotaurs [ID resolving capabilities](https://github.com/modrinth/minotaur/pull/26) for better readability
- The config class utilizes NIO directly instead of converting paths to files and caches a single Gson instance for both reading and writing
- MixinOptions now has a lambda since IMO it looks better

Have you considered merging your forge and fabric codebases using something like architectury or custom build scripts with shadow?
It would make additions like this easier and the code is mostly the same anyways