### PR TITLE
Disable global bans

### DIFF
--- a/src/main/java/com/aizistral/nochatreports/NoBanUserApiService.java
+++ b/src/main/java/com/aizistral/nochatreports/NoBanUserApiService.java
@@ -1,0 +1,14 @@
+package com.aizistral.nochatreports;
+
+import com.mojang.authlib.minecraft.UserApiService;
+
+public class NoBanUserApiService extends UserApiServiceDelegate {
+	public NoBanUserApiService(UserApiService d) {
+		super(d);
+	}
+
+	@Override
+	public UserProperties properties() {
+		return OFFLINE_PROPERTIES;
+	}
+}

--- a/src/main/java/com/aizistral/nochatreports/UserApiServiceDelegate.java
+++ b/src/main/java/com/aizistral/nochatreports/UserApiServiceDelegate.java
@@ -1,0 +1,44 @@
+package com.aizistral.nochatreports;
+
+import com.mojang.authlib.minecraft.TelemetrySession;
+import com.mojang.authlib.minecraft.UserApiService;
+import com.mojang.authlib.yggdrasil.response.KeyPairResponse;
+
+import java.util.UUID;
+import java.util.concurrent.Executor;
+
+import org.jetbrains.annotations.Nullable;
+
+public class UserApiServiceDelegate implements UserApiService {
+	protected final UserApiService d;
+
+	public UserApiServiceDelegate(UserApiService d) {
+		this.d = d;
+	}
+
+	@Override
+	public UserProperties properties() {
+		return this.d.properties();
+	}
+
+	@Override
+	public boolean isBlockedPlayer(UUID playerID) {
+		return this.d.isBlockedPlayer(playerID);
+	}
+
+	@Override
+	public void refreshBlockList() {
+		this.d.refreshBlockList();
+	}
+
+	@Override
+	public TelemetrySession newTelemetrySession(Executor executor) {
+		return this.d.newTelemetrySession(executor);
+	}
+
+	@Nullable
+	@Override
+	public KeyPairResponse getKeyPair() {
+		return this.d.getKeyPair();
+	}
+}

--- a/src/main/java/com/aizistral/nochatreports/mixins/MixinMinecraft.java
+++ b/src/main/java/com/aizistral/nochatreports/mixins/MixinMinecraft.java
@@ -1,0 +1,21 @@
+package com.aizistral.nochatreports.mixins;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.main.GameConfig;
+
+import com.mojang.authlib.minecraft.UserApiService;
+import com.mojang.authlib.yggdrasil.YggdrasilAuthenticationService;
+
+import com.aizistral.nochatreports.NoBanUserApiService;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(Minecraft.class)
+public class MixinMinecraft {
+	@Inject(method = "createUserApiService", at = @At("RETURN"), cancellable = true)
+	private void wrapUserApiService(YggdrasilAuthenticationService authService, GameConfig config, CallbackInfoReturnable<UserApiService> cir) {
+		cir.setReturnValue(new NoBanUserApiService(cir.getReturnValue()));
+	}
+}

--- a/src/main/resources/nochatreports.mixins.json
+++ b/src/main/resources/nochatreports.mixins.json
@@ -1,27 +1,27 @@
 {
-  "required": true,
-  "minVersion": "0.8",
-  "package": "com.aizistral.nochatreports.mixins",
-  "compatibilityLevel": "JAVA_17",
-  "refmap": "nochatreports.refmap.json",
-  "verbose": true,
-  "mixins": [
-	"MixinPlayer",
-	"MixinServerboundChatPacket",
-	"MixinServerPlayer"
-  ],
-  "client": [
-	"MixinLocalPlayer",
-	"MixinMinecraft",
-	"MixinClientPacketListener",
-	"MixinOptions",
-	"MixinProfileKeyPairManager",
-	"MixinClientTelemetryManager"
-  ],
-  "server": [
-	"MixinDedicatedServer"
-  ],
-  "injectors": {
-    "defaultRequire": 1
-  }
+	"required": true,
+	"minVersion": "0.8",
+	"package": "com.aizistral.nochatreports.mixins",
+	"compatibilityLevel": "JAVA_17",
+	"refmap": "nochatreports.refmap.json",
+	"verbose": true,
+	"mixins": [
+		"MixinPlayer",
+		"MixinServerboundChatPacket",
+		"MixinServerPlayer"
+	],
+	"client": [
+		"MixinLocalPlayer",
+		"MixinMinecraft",
+		"MixinClientPacketListener",
+		"MixinOptions",
+		"MixinProfileKeyPairManager",
+		"MixinClientTelemetryManager"
+	],
+	"server": [
+		"MixinDedicatedServer"
+	],
+	"injectors": {
+		"defaultRequire": 1
+	}
 }

--- a/src/main/resources/nochatreports.mixins.json
+++ b/src/main/resources/nochatreports.mixins.json
@@ -12,6 +12,7 @@
   ],
   "client": [
 	"MixinLocalPlayer",
+	"MixinMinecraft",
 	"MixinClientPacketListener",
 	"MixinOptions",
 	"MixinProfileKeyPairManager",


### PR DESCRIPTION
As far as I can see, this covers only part of the new "functionality," if a player is already globally banned they will not be able to join servers regardless of whether the server/client has this mod installed. This also disables that.