### PR TITLE
Add catalan translation

### DIFF
--- a/.github/workflows/gitlabsync.yml
+++ b/.github/workflows/gitlabsync.yml
@@ -1,0 +1,19 @@
+name: GitlabSync
+
+on:
+  - push
+  - delete
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    name: Git Repo Sync
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - uses: wangchucheng/git-repo-sync@v0.1.0
+      with:
+        target-url: ${{ secrets.TARGET_URL }}
+        target-username: ${{ secrets.TARGET_USERNAME }}
+        target-token: ${{ secrets.TARGET_TOKEN }}

--- a/build.gradle
+++ b/build.gradle
@@ -61,6 +61,7 @@ curseforge {
 		
 		addGameVersion '1.19'
 		addGameVersion 'Fabric'
+		addGameVersion 'Quilt'
 		addGameVersion 'Java 17'
 		
 		relations {
@@ -90,7 +91,7 @@ modrinth {
 	changelog = rootProject.file("docs/changelog.html").text
     uploadFile = remapJar
     gameVersions = ["1.19"]
-	loaders = ['fabric']
+	loaders = ['fabric', 'quilt']
 	
 	dependencies {
 		// The scope can be `required`, `optional`, or `incompatible`

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # No Chat Reports
 
-**Current Version:** 1.19-v1.2.1
+**Current Version:** 1.19-v1.2.2
 
 **Minecraft Version:** 1.19.x
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # No Chat Reports
 
-**Current Version:** 1.19-v1.2.2
+**Current Version:** 1.19-v1.2.3
 
 **Minecraft Version:** 1.19.x
 

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -1,5 +1,13 @@
 <h3><b>The Changelog:</b></h3><br/>
 
+<h5><b>[Release 1.19-v1.2.3]:</b></h5>
+<p>
+&nbsp;- Added Polish translation (<a href="https://github.com/Aizistral-Studios/No-Chat-Reports/pull/24">thanks GerbilPL, #24</a>);<br/>
+&nbsp;- Added Russian translation (<a href="https://github.com/Aizistral-Studios/No-Chat-Reports/pull/25">thanks sst4nk0, #25</a>);<br/>
+&nbsp;- Added German translation (<a href="https://github.com/Aizistral-Studios/No-Chat-Reports/pull/34">thanks Doenerstyle, #34</a>);<br/>
+&nbsp;- Added French translation (<a href="https://github.com/Aizistral-Studios/No-Chat-Reports/pull/29">thanks Mrredstone5230, #29</a>).<br/>
+<p/><br/><br/>
+
 <h5><b>[Release 1.19-v1.2.2]:</b></h5>
 <p>
 &nbsp;- Added Simplified Chinese translation (<a href="https://github.com/Aizistral-Studios/No-Chat-Reports/pull/21">thanks CJYKK, #21</a>);<br/>

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -1,5 +1,12 @@
 <h3><b>The Changelog:</b></h3><br/>
 
+<h5><b>[Release 1.19-v1.2.2]:</b></h5>
+<p>
+&nbsp;- Added Simplified Chinese translation (<a href="https://github.com/Aizistral-Studios/No-Chat-Reports/pull/21">thanks CJYKK, #21</a>);<br/>
+&nbsp;- This and all further releases for Fabric will be marked Quilt-compatible.<br/>
+<p/><br/><br/>
+
+
 <h5><b>[Release 1.19-v1.2.1]:</b></h5>
 <p>
 &nbsp;- Replaced all overwrites with injects, which should hopefully increase compatibility with other mods (<a href="https://github.com/Aizistral-Studios/No-Chat-Reports/pull/7">thanks ToxicAven, #7</a>);<br/>

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ yarn_mappings=1.19+build.4
 loader_version=0.14.8
 
 # Mod Properties
-mod_version=1.19-v1.2.1
+mod_version=1.19-v1.2.2
 maven_group=com.aizistral.nochatreports
 archives_base_name=NoChatReports-FABRIC
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ yarn_mappings=1.19+build.4
 loader_version=0.14.8
 
 # Mod Properties
-mod_version=1.19-v1.2.2
+mod_version=1.19-v1.2.3
 maven_group=com.aizistral.nochatreports
 archives_base_name=NoChatReports-FABRIC
 

--- a/src/main/resources/assets/nochatreports/lang/de_de.json
+++ b/src/main/resources/assets/nochatreports/lang/de_de.json
@@ -1,0 +1,5 @@
+{
+	"gui.nochatreport.secureChat": "Diese Option kann nicht mit No Chat Reports verwendet werden, da keine Signaturen zum Verifizieren vorhanden sind.",
+	"gui.nochatreport.noReporting": "Nachrichten melden ist auf diesem Server dank No Chat Reports deaktiviert.",
+	"disconnect.nochatreports.client": "Dieser Server hat No Chat Reports nicht installiert, aber du hast eingestellt, dass es auf Servern notwendig ist."
+}

--- a/src/main/resources/assets/nochatreports/lang/fr_fr.json
+++ b/src/main/resources/assets/nochatreports/lang/fr_fr.json
@@ -1,0 +1,3 @@
+{
+  "gui.nochatreport.secureChat": "Cette option ne fonctionne pas avec No Chat Reports puisqu'il n'y a pas de signature à vérifier."
+}

--- a/src/main/resources/assets/nochatreports/lang/fr_fr.json
+++ b/src/main/resources/assets/nochatreports/lang/fr_fr.json
@@ -1,3 +1,5 @@
 {
-  "gui.nochatreport.secureChat": "Cette option ne fonctionne pas avec No Chat Reports puisqu'il n'y a pas de signature à vérifier."
+  "gui.nochatreport.secureChat": "Cette option ne fonctionne pas avec No Chat Reports puisqu'il n'y a pas de signature à vérifier.",
+  "gui.nochatreport.noReporting": "Les signalements de chat sont désactivés sur ce serveur grâce à No Chat Reports.",
+	"disconnect.nochatreports.client": "Ce serveur n'a pas No Chat Reports et vous avez configuré que vous le vouliez toujours."
 }

--- a/src/main/resources/assets/nochatreports/lang/fr_fr.json
+++ b/src/main/resources/assets/nochatreports/lang/fr_fr.json
@@ -1,5 +1,5 @@
 {
   "gui.nochatreport.secureChat": "Cette option ne fonctionne pas avec No Chat Reports puisqu'il n'y a pas de signature à vérifier.",
   "gui.nochatreport.noReporting": "Les signalements de chat sont désactivés sur ce serveur grâce à No Chat Reports.",
-	"disconnect.nochatreports.client": "Ce serveur n'a pas No Chat Reports et vous avez configuré que vous le vouliez toujours."
+  "disconnect.nochatreports.client": "Ce serveur n'a pas No Chat Reports et vous avez configuré que vous le vouliez toujours."
 }

--- a/src/main/resources/assets/nochatreports/lang/pl_pl.json
+++ b/src/main/resources/assets/nochatreports/lang/pl_pl.json
@@ -1,0 +1,5 @@
+{
+	"gui.nochatreport.secureChat": "Ta opcja nie działa z No Chat Reports, ponieważ nie ma podpisów do weryfikacji.",
+	"gui.nochatreport.noReporting": "Raporty czatu są wyłączone na tym serwerze, dzięki No Chat Reports.",
+	"disconnect.nochatreports.client": "Na tym serwerze nie ma No Chat Reports, a został skonfigurowany tak, aby był wymagany na serwerze."
+}

--- a/src/main/resources/assets/nochatreports/lang/ru_ru.json
+++ b/src/main/resources/assets/nochatreports/lang/ru_ru.json
@@ -1,5 +1,5 @@
 {
-	"gui.nochatreport.secureChat": "Этот параметр не работает с No Chat Reports, отсутствуют подписи для проверки.",
+	"gui.nochatreport.secureChat": "Этот параметр не работает с No Chat Reports ввиду отсутствия криптографических сигнатур.",
 	"gui.nochatreport.noReporting": "Жалобы на чат отключены на этом сервере благодаря No Chat Reports.",
-	"disconnect.nochatreports.client": "У вас отсутствует модификация No Chat Reports. (обязательная на сервере)"
+	"disconnect.nochatreports.client": "У вас отсутствует модификация No Chat Reports (обязательная на сервере)."
 }

--- a/src/main/resources/assets/nochatreports/lang/ru_ru.json
+++ b/src/main/resources/assets/nochatreports/lang/ru_ru.json
@@ -1,0 +1,5 @@
+{
+	"gui.nochatreport.secureChat": "Этот параметр не работает с No Chat Reports, отсутствуют подписи для проверки.",
+	"gui.nochatreport.noReporting": "Жалобы на чат отключены на этом сервере благодаря No Chat Reports.",
+	"disconnect.nochatreports.client": "У вас отсутствует модификация No Chat Reports. (обязательная на сервере)"
+}

--- a/src/main/resources/assets/nochatreports/lang/zh_cn.json
+++ b/src/main/resources/assets/nochatreports/lang/zh_cn.json
@@ -1,0 +1,5 @@
+{
+	"gui.nochatreport.secureChat": "此选项无法与No Chat Reports一起使用，因为没有可用于验证的签名。",
+	"gui.nochatreport.noReporting": "聊天举报在此服务器上被禁用，由No Chat Reports提供。",
+	"disconnect.nochatreports.client": "此服务器没有No Chat Reports，但你已将其配置为要求在服务器上安装。"
+}


### PR DESCRIPTION
`{
	"gui.nochatreport.secureChat": "Aquesta opció no pot funcionar amb No Chat Reports, ja que no n'hi ha signatures per a verificar.",
	"gui.nochatreport.noReporting": "Els reports del xat hi són deshabilitats en aquest servidor, cortesia de No Chat Reports.",
	"disconnect.nochatreports.client": "Aquest servidor no té No Chat Reports, i vostè el té configurat perquè sigui requerit al servidor.",
	"gui.nochatreports.status_secure": "Aquest servidor té No Chat Reports instal·lat, o preveu que els seus missatges siguin reportats d'altra forma coneguda. Pots xatejar amb seguretat.",
	"gui.nochatreports.status_unintrusive": "Aquest servidor no evita els reports de xat, però permet que enviïs missatges sense signatura. Tècnicament - encara poden ser reportats a Mojang, però generalment, no seran considerats evidencia vàlida, i és poc probable que es prengui alguna mesura sobre aquests.",
	"gui.nochatreports.status_insecure": "Aquest servidor demana que tots els missatges enviats per jugadors tinguin signatura, i vostè ha estat d'acord amb aquests termes. Tot el que enviïs en el xat pot ser usat com a evidència incriminatòria en la seva contra en el report. Pots eliminar aquest servidor de NoChatReports.json en la teva carpeta de configuració manualment per a no ser advertit altra vegada.",
	"gui.nochatreports.status_unknown": "No Chat Reports no ha pogut avaluar la seguretat d'aquest servidor. Això no deuria haver passat, si us plau informi d'aquest error al desenvolupador d'aquest mod.",
	"gui.nochatreports.unsafe_server.header": "Precaució: Servidor insegur",
	"gui.nochatreports.unsafe_server.contents": "Aquest servidor requereix que tots els missatges tinguin signatura, això significa que poden ser reportats a Mojang. Això probablement significa que el propietari del servidor ha mantingut 'enforce-secure-profile' habilitat en server.properties, que és el valor per defecte des de 1.19.1. Pots escollir jugar de totes formes, però No Chat Reports podrà protegir-te.",
	"gui.nochatreports.unsafe_server.check": "No tornar a mostrar per aquest servidor.",
	"gui.nochatrepords.reload_config_tooltip": "Recarregar la configuració de No Chat Reports. Utilitzar amb compte."
}`