### PR TITLE
Ignore server blocklist & hide multiplayer warning screen

### DIFF
--- a/src/main/java/com/aizistral/nochatreports/NoChatReportsClient.java
+++ b/src/main/java/com/aizistral/nochatreports/NoChatReportsClient.java
@@ -51,14 +51,15 @@ public class NoChatReportsClient implements ClientModInitializer {
 		ClientPlayConnectionEvents.JOIN.register(this::onPlayReady);
 		ClientPlayConnectionEvents.DISCONNECT.register(this::onDisconnect);
 		ScreenEvents.AFTER_INIT.register(this::onScreenInit);
-
-		if (!Minecraft.getInstance().options.skipMultiplayerWarning) {
-			Minecraft.getInstance().options.skipMultiplayerWarning = true;
-			Minecraft.getInstance().options.save();
-		}
 	}
 
 	private void onScreenInit(Minecraft client, Screen screen, int scaledWidth, int scaledHeight) {
+		if (screen instanceof TitleScreen) {
+			if (!Minecraft.getInstance().options.skipMultiplayerWarning) {
+				Minecraft.getInstance().options.skipMultiplayerWarning = true;
+				Minecraft.getInstance().options.save();
+			}
+		}
 		if (screen instanceof AccessorDisconnectedScreen dsc) {
 			if (screenOverride)
 				return;

--- a/src/main/java/com/aizistral/nochatreports/NoChatReportsClient.java
+++ b/src/main/java/com/aizistral/nochatreports/NoChatReportsClient.java
@@ -51,6 +51,11 @@ public class NoChatReportsClient implements ClientModInitializer {
 		ClientPlayConnectionEvents.JOIN.register(this::onPlayReady);
 		ClientPlayConnectionEvents.DISCONNECT.register(this::onDisconnect);
 		ScreenEvents.AFTER_INIT.register(this::onScreenInit);
+
+		if (!Minecraft.getInstance().options.skipMultiplayerWarning) {
+			Minecraft.getInstance().options.skipMultiplayerWarning = true;
+			Minecraft.getInstance().options.save();
+		}
 	}
 
 	private void onScreenInit(Minecraft client, Screen screen, int scaledWidth, int scaledHeight) {

--- a/src/main/java/com/aizistral/nochatreports/core/NoReportsConfig.java
+++ b/src/main/java/com/aizistral/nochatreports/core/NoReportsConfig.java
@@ -41,7 +41,7 @@ public class NoReportsConfig {
 	private static NoReportsConfig INSTANCE;
 	private boolean demandOnClient = true, demandOnServer = false, enableDebugLog = false,
 			convertToGameMessage = false, showServerSafety = true, suppressVanillaSecurityNotices = true,
-			alwaysHideReportButton = false, versionEasterEgg = true, disableTelemetry = true,
+			alwaysHideReportButton = false, versionEasterEgg = true, disableTelemetry = true, disableServerBlocklist = true,
 			showReloadButton = true;
 	private List<String> whitelistedServers;
 
@@ -230,6 +230,16 @@ public class NoReportsConfig {
 
 	public static boolean disableTelemetry() {
 		return getInstance().disableTelemetry;
+	}
+
+	/**
+	 * @return True if the Mojang server blocklist should be ignored.<br><br>
+	 *
+	 * This is true by default.
+	 */
+
+	public static boolean disableServerBlocklist() {
+		return getInstance().disableServerBlocklist;
 	}
 
 	/**

--- a/src/main/java/com/aizistral/nochatreports/mixins/client/MixinMojangBlockListSupplier.java
+++ b/src/main/java/com/aizistral/nochatreports/mixins/client/MixinMojangBlockListSupplier.java
@@ -1,0 +1,28 @@
+package com.aizistral.nochatreports.mixins.client;
+
+import com.aizistral.nochatreports.core.NoReportsConfig;
+import com.mojang.patchy.MojangBlockListSupplier;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Overwrite;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import java.util.function.Predicate;
+
+@Mixin(MojangBlockListSupplier.class)
+public class MixinMojangBlockListSupplier {
+
+    /**
+     * @reason Ignore the Mojang server blocklist
+     */
+
+    @Inject(method = "createBlockList", at = @At("HEAD"), cancellable = true, remap = false)
+    private void createBlockList(CallbackInfoReturnable<Predicate<String>> info){
+        if(NoReportsConfig.disableServerBlocklist()) {
+            info.setReturnValue(null);
+            info.cancel(); // don't bother downloading it in the first place
+        }
+    }
+}

--- a/src/main/resources/nochatreports.mixins.json
+++ b/src/main/resources/nochatreports.mixins.json
@@ -26,7 +26,8 @@
 	"client.MixinClientboundHelloPacket",
 	"client.MixinJoinMultiplayerScreen",
 	"client.MixinGuiMessageTag",
-	"client.MixinToastComponent"
+	"client.MixinToastComponent",
+	"client.MixinMojangBlockListSupplier"
   ],
   "server": [
 	"server.MixinDedicatedServer"


### PR DESCRIPTION
Since we disable telemetry, might as well knock out another Mojang anti-feature. This also disables the 'unmoderated content' warning screen that shows up when you first open the server list.