### PR TITLE
Sign automatically when requested

### DIFF
--- a/src/main/java/com/aizistral/nochatreports/config/ModMenuIntegration.java
+++ b/src/main/java/com/aizistral/nochatreports/config/ModMenuIntegration.java
@@ -164,6 +164,13 @@ public final class ModMenuIntegration implements ModMenuApi {
 					.setSaveConsumer(newValue -> NCRConfig.getClient().whitelistAllServers = newValue)
 					.build());
 
+			// Set an option for whitelistAllServers
+			technical.addEntry(entryBuilder.startBooleanToggle(Component.translatable("option.NoChatReports.skipSigningWarning"), NCRConfig.getClient().skipSigningWarning)
+					.setDefaultValue(false)
+					.setTooltip(this.makeTooltip("option.NoChatReports.skipSigningWarning.tooltip"))
+					.setSaveConsumer(newValue -> NCRConfig.getClient().skipSigningWarning = newValue)
+					.build());
+
 			// Set an option for showNCRButton
 			technical.addEntry(entryBuilder.startBooleanToggle(Component.translatable("option.NoChatReports.showNCRButton"), NCRConfig.getClient().showNCRButton)
 					.setDefaultValue(true)

--- a/src/main/java/com/aizistral/nochatreports/config/ModMenuIntegration.java
+++ b/src/main/java/com/aizistral/nochatreports/config/ModMenuIntegration.java
@@ -164,7 +164,7 @@ public final class ModMenuIntegration implements ModMenuApi {
 					.setSaveConsumer(newValue -> NCRConfig.getClient().whitelistAllServers = newValue)
 					.build());
 
-			// Set an option for whitelistAllServers
+			// Set an option for skipSigningWarning
 			technical.addEntry(entryBuilder.startBooleanToggle(Component.translatable("option.NoChatReports.skipSigningWarning"), NCRConfig.getClient().skipSigningWarning)
 					.setDefaultValue(false)
 					.setTooltip(this.makeTooltip("option.NoChatReports.skipSigningWarning.tooltip"))

--- a/src/main/java/com/aizistral/nochatreports/config/NCRConfigClient.java
+++ b/src/main/java/com/aizistral/nochatreports/config/NCRConfigClient.java
@@ -26,7 +26,7 @@ public final class NCRConfigClient extends JSONConfig {
 			hideModifiedMessageIndicators = true, hideSystemMessageIndicators = true, hideWarningToast = true,
 			alwaysHideReportButton = false, disableTelemetry = true, showReloadButton = true,
 			whitelistAllServers = false, verifiedIconEnabled = true, showNCRButton = true,
-			enableMod = true, skipRealmsWarning = false, hideSigningRequestMessage = false;
+			enableMod = true, skipRealmsWarning = false, hideSigningRequestMessage = false, skipSigningWarning = false;
 	protected int verifiedIconOffsetX = 0, verifiedIconOffsetY = 0;
 
 
@@ -220,5 +220,7 @@ public final class NCRConfigClient extends JSONConfig {
 	public boolean hideSigningRequestMessage() {
 		return this.hideSigningRequestMessage;
 	}
+
+	public boolean skipSigningWarning() { return this.skipSigningWarning; }
 
 }

--- a/src/main/java/com/aizistral/nochatreports/mixins/client/MixinChatListener.java
+++ b/src/main/java/com/aizistral/nochatreports/mixins/client/MixinChatListener.java
@@ -52,6 +52,11 @@ public class MixinChatListener {
 				if (UnsafeServerScreen.hideThisSession() || ServerSafetyState.allowChatSigning())
 					return;
 
+				if(NCRConfig.getClient().skipSigningWarning()){
+					ServerSafetyState.setAllowChatSigning(true);
+					return;
+				}
+
 				Minecraft.getInstance().setScreen(new UnsafeServerScreen(Minecraft.getInstance().screen
 						instanceof ChatScreen chat ? chat : new ChatScreen("")));
 

--- a/src/main/resources/assets/nochatreports/lang/en_us.json
+++ b/src/main/resources/assets/nochatreports/lang/en_us.json
@@ -97,6 +97,8 @@
 	"option.NoChatReports.showReloadButton.tooltip": "Adds a button for config reloading to multiplayer menu.",
 	"option.NoChatReports.whitelistAllServers": "Whitelist all servers",
 	"option.NoChatReports.whitelistAllServers.tooltip": "Makes the mod behave as if all servers were added to §oWhitelisted Servers§r list.",
+	"option.NoChatReports.skipSigningWarning": "Sign automatically when requested",
+	"option.NoChatReports.skipSigningWarning.tooltip": "Skips the \"Chat Signing Requested\" warning and signs the chat automatically when the server requires it.",
 	"option.NoChatReports.showNCRButton": "Show NCR button",
 	"option.NoChatReports.showNCRButton.tooltip": "Adds a button that toggles most of the mod's client-sided functionality to multiplayer menu.",
 	"option.NoChatReports.enableMod": "Enable mod",

--- a/src/main/resources/assets/nochatreports/lang/et_ee.json
+++ b/src/main/resources/assets/nochatreports/lang/et_ee.json
@@ -97,6 +97,8 @@
 	"option.NoChatReports.showReloadButton.tooltip": "Lisab mitmikmängu serverite loendisse seadistuste taaslaadimise nupu.",
 	"option.NoChatReports.whitelistAllServers": "Kõik serverid lubamisloendisse",
 	"option.NoChatReports.whitelistAllServers.tooltip": "Sunnib modi käituma nii, nagu kõik serverid oleksid lisatud §olubamisloendis serverite§r loendisse.",
+	"option.NoChatReports.skipSigningWarning": "Signeeri nõude korral automaatselt",
+	"option.NoChatReports.skipSigningWarning.tooltip": "Jätab vahele hoiatuskuva \"taodeldi vestluse signeerimist\", signeerides vestluse automaatselt, kui server seda nõuab.",
 	"option.NoChatReports.showNCRButton": "Kuva NCRi nupp",
 	"option.NoChatReports.showNCRButton.tooltip": "Lisab mitmikmängumenüüsse nupu, mis lülitab enamikku modi kliendipoolsest funktsionaalsusest.",
 	"option.NoChatReports.enableMod": "Mod lubatud",


### PR DESCRIPTION
Adds an option to fix #268 or at least that's what I wanted the option to do. Considering how you named that issue I think you misunderstood my idea a bit though, hence this PR to show you exactly what I want.

I know that NCR for 1.19.2 had the logic to recheck whitelisted servers every 12h and I agree that that logic can be implemented later, I just think that the option I suggested in this PR should be implemented sooner.