### PR TITLE
Resend message automatically when warning is skipped

### DIFF
--- a/src/main/java/com/aizistral/nochatreports/mixins/client/MixinChatListener.java
+++ b/src/main/java/com/aizistral/nochatreports/mixins/client/MixinChatListener.java
@@ -66,6 +66,11 @@ public class MixinChatListener {
 					});
 
 					ServerSafetyState.setAllowChatSigning(true);
+
+					if (NCRConfig.getClient().hideSigningRequestMessage()) {
+						info.cancel();
+					}
+
 					return;
 				}
 

--- a/src/main/java/com/aizistral/nochatreports/mixins/client/MixinChatListener.java
+++ b/src/main/java/com/aizistral/nochatreports/mixins/client/MixinChatListener.java
@@ -4,6 +4,7 @@ import java.time.Instant;
 import java.util.Base64;
 import java.util.UUID;
 
+import net.minecraft.client.gui.screens.Screen;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
@@ -55,6 +56,9 @@ public class MixinChatListener {
 				if(NCRConfig.getClient().skipSigningWarning()){
 					ServerSafetyState.setAllowChatSigning(true);
 					var chatScr = Minecraft.getInstance().screen instanceof ChatScreen chat ? chat : new ChatScreen("");
+					chatScr.init(Minecraft.getInstance(),
+							Minecraft.getInstance().getWindow().getGuiScaledWidth(),
+							Minecraft.getInstance().getWindow().getGuiScaledHeight());
 					chatScr.handleChatInput(NCRConfig.getEncryption().getLastMessage(), false);
 					return;
 				}

--- a/src/main/java/com/aizistral/nochatreports/mixins/client/MixinChatListener.java
+++ b/src/main/java/com/aizistral/nochatreports/mixins/client/MixinChatListener.java
@@ -53,14 +53,19 @@ public class MixinChatListener {
 				if (UnsafeServerScreen.hideThisSession() || ServerSafetyState.allowChatSigning())
 					return;
 
-				if(NCRConfig.getClient().skipSigningWarning()){
+				if (NCRConfig.getClient().skipSigningWarning()) {
+					ServerSafetyState.scheduleSigningAction(() -> {
+						var mc = Minecraft.getInstance();
+						var chatScr = mc.screen instanceof ChatScreen chat ? chat : null;
+
+						if (chatScr == null) {
+							chatScr = new ChatScreen("");
+							chatScr.init(mc, mc.getWindow().getGuiScaledWidth(), mc.getWindow().getGuiScaledHeight());
+						}
+						chatScr.handleChatInput(NCRConfig.getEncryption().getLastMessage(), false);
+					});
+
 					ServerSafetyState.setAllowChatSigning(true);
-					var instance = Minecraft.getInstance(); 
-					var chatScr = instance.screen instanceof ChatScreen chat ? chat : new ChatScreen("");
-					chatScr.init(instance,
-							instance.getWindow().getGuiScaledWidth(),
-							instance.getWindow().getGuiScaledHeight());
-					chatScr.handleChatInput(NCRConfig.getEncryption().getLastMessage(), false);
 					return;
 				}
 

--- a/src/main/java/com/aizistral/nochatreports/mixins/client/MixinChatListener.java
+++ b/src/main/java/com/aizistral/nochatreports/mixins/client/MixinChatListener.java
@@ -54,6 +54,8 @@ public class MixinChatListener {
 
 				if(NCRConfig.getClient().skipSigningWarning()){
 					ServerSafetyState.setAllowChatSigning(true);
+					var chatScr = Minecraft.getInstance().screen instanceof ChatScreen chat ? chat : new ChatScreen("");
+					chatScr.handleChatInput(NCRConfig.getEncryption().getLastMessage(), false);
 					return;
 				}
 

--- a/src/main/java/com/aizistral/nochatreports/mixins/client/MixinChatListener.java
+++ b/src/main/java/com/aizistral/nochatreports/mixins/client/MixinChatListener.java
@@ -55,10 +55,11 @@ public class MixinChatListener {
 
 				if(NCRConfig.getClient().skipSigningWarning()){
 					ServerSafetyState.setAllowChatSigning(true);
-					var chatScr = Minecraft.getInstance().screen instanceof ChatScreen chat ? chat : new ChatScreen("");
-					chatScr.init(Minecraft.getInstance(),
-							Minecraft.getInstance().getWindow().getGuiScaledWidth(),
-							Minecraft.getInstance().getWindow().getGuiScaledHeight());
+					var instance = Minecraft.getInstance(); 
+					var chatScr = instance.screen instanceof ChatScreen chat ? chat : new ChatScreen("");
+					chatScr.init(instance,
+							instance.getWindow().getGuiScaledWidth(),
+							instance.getWindow().getGuiScaledHeight());
 					chatScr.handleChatInput(NCRConfig.getEncryption().getLastMessage(), false);
 					return;
 				}


### PR DESCRIPTION
Makes the warning skipping method resend the first message right after enabling the signature sending.

Except... it doesn't work, haha.

<details>
<summary>
Old
</summary>

I've tried to describe `chatScr` as

* the one you see in the code now
* new ChatScreen instance from a named variable `var chatScr = new ChatScreen("");` `chatScr.handleChatInput...`
* anonymous new chatscreen instance `(new ChatScreen("")).handleChatInput...`

and I get the following crash upon sending a message in a signing-required server:

```
java.lang.NullPointerException: Cannot read field "field_1724" because "this.field_22787" is null
	at net.minecraft.class_408.method_44056(class_408.java:256)
	at net.minecraft.class_7594.handler$zdk000$onHandleSystemMessage(class_7594.java:558)
	at net.minecraft.class_7594.method_44736(class_7594.java)
	at net.minecraft.class_634.method_43596(class_634.java:842)
	at net.minecraft.class_7439.method_43631(class_7439.java:20)
	at net.minecraft.class_7439.method_11054(class_7439.java:7)
	at net.minecraft.class_2600.method_11072(class_2600.java:22)
	at net.minecraft.class_1255.method_18859(class_1255.java:156)
	at net.minecraft.class_4093.method_18859(class_4093.java:23)
	at net.minecraft.class_1255.method_16075(class_1255.java:130)
	at net.minecraft.class_1255.method_5383(class_1255.java:115)
	at net.minecraft.class_310.method_1523(class_310.java:1136)
	at net.minecraft.class_310.method_1514(class_310.java:776)
	at net.minecraft.client.main.Main.method_44604(Main.java:244)
	at net.minecraft.client.main.Main.main(Main.java:51)
	at net.fabricmc.loader.impl.game.minecraft.MinecraftGameProvider.launch(MinecraftGameProvider.java:461)
	at net.fabricmc.loader.impl.launch.knot.Knot.launch(Knot.java:74)
	at net.fabricmc.loader.impl.launch.knot.KnotClient.main(KnotClient.java:23)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
	at java.base/java.lang.reflect.Method.invoke(Method.java:577)
	at org.prismlauncher.impl.OneSixLauncher.invokeMain(OneSixLauncher.java:104)
	at org.prismlauncher.impl.OneSixLauncher.launchWithMainClass(OneSixLauncher.java:176)
	at org.prismlauncher.impl.OneSixLauncher.launch(OneSixLauncher.java:186)
	at org.prismlauncher.EntryPoint.listen(EntryPoint.java:144)
	at org.prismlauncher.EntryPoint.main(EntryPoint.java:74)
```

Not sure if there is a way to test in debugger with a signed in account yet, so this was indeed compiled and put to a separate instance.

Tested only on 22w44a, so maybe 22w45a breaks this even more :shrug:
</details>

Edit: now it no longer crashes, but instead of resending the user's last message, it sends the "Server refused..." again.