### PR TITLE
Bump deps

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,12 +19,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: validate gradle wrapper
         uses: gradle/wrapper-validation-action@v1
       - name: setup jdk ${{ matrix.java }}
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
+          distribution: temurin
           java-version: ${{ matrix.java }}
       - name: make gradle wrapper executable
         if: ${{ runner.os != 'Windows' }}

--- a/.github/workflows/gitlabsync.yml
+++ b/.github/workflows/gitlabsync.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Git Repo Sync
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
     - uses: wangchucheng/git-repo-sync@v0.1.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,7 @@ archives_base_name=NoChatReports-FABRIC
 
 # Dependencies
 fabric_version=0.66.4+1.19.3
-mod_menu_version=5.0.0-alpha.1
+mod_menu_version=5.0.0-alpha.3
 cloth_config_version=9.0.92
 
 # Publishing


### PR DESCRIPTION
[Node 12 actions are deprecated](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12), so I've bumped `actions/checkout` and `actions/setup-java` accordingly.

While we're here, I bumped Mod Menu to 5.0.0-alpha.3, the latest 1.19.3 snapshot version.