### PR TITLE
Default signing mode dropdown

### DIFF
--- a/src/main/java/com/aizistral/nochatreports/config/ModMenuIntegration.java
+++ b/src/main/java/com/aizistral/nochatreports/config/ModMenuIntegration.java
@@ -15,6 +15,7 @@ import net.minecraft.locale.Language;
 import net.minecraft.network.chat.ClickEvent;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.HoverEvent;
+import net.minecraft.network.chat.MutableComponent;
 
 import java.util.List;
 import java.util.stream.Stream;
@@ -27,7 +28,6 @@ import java.util.stream.Stream;
 
 @Environment(EnvType.CLIENT)
 public final class ModMenuIntegration implements ModMenuApi {
-
 	private Component[] makeTooltip(String key) {
 		String localized = Language.getInstance().getOrDefault(key);
 		List<String> list = FontHelper.wrap(Minecraft.getInstance().font, localized, 250);
@@ -42,6 +42,12 @@ public final class ModMenuIntegration implements ModMenuApi {
 
 	@Override
 	public ConfigScreenFactory<?> getModConfigScreenFactory() {
+		MutableComponent signingTooltip = Component.translatable("option.NoChatReports.defaultSigningMode.tooltip")
+				.append("\nALWAYS: ").append(Component.translatable("gui.nochatreports.signing_mode.always.tooltip"))
+				.append("\nNEVER: ").append(Component.translatable("gui.nochatreports.signing_mode.never.tooltip"))
+				.append("\nPROMPT: ").append(Component.translatable("gui.nochatreports.signing_mode.prompt.tooltip"))
+				.append("\nON_DEMAND: ").append(Component.translatable("gui.nochatreports.signing_mode.on_demand.tooltip"));
+
 		return screen -> {
 
 			// Get the previous screen
@@ -76,7 +82,7 @@ public final class ModMenuIntegration implements ModMenuApi {
 			client.addEntry(entryBuilder.startStringDropdownMenu(Component.translatable("option.NoChatReports.defaultSigningMode"), NCRConfig.getClient().defaultSigningMode.toString()
 					)
 					.setDefaultValue(SigningMode.PROMPT.toString())
-					.setTooltip(this.makeTooltip("option.NoChatReports.defaultSigningMode.tooltip"))
+					.setTooltip(signingTooltip)
 					.setSelections(Stream.of(SigningMode.values()).map(SigningMode::name).toList())
 					.setSaveConsumer(newValue -> NCRConfig.getClient().defaultSigningMode = SigningMode.valueOf(newValue))
 					.setSuggestionMode(false)

--- a/src/main/java/com/aizistral/nochatreports/config/ModMenuIntegration.java
+++ b/src/main/java/com/aizistral/nochatreports/config/ModMenuIntegration.java
@@ -1,13 +1,13 @@
 package com.aizistral.nochatreports.config;
 
 import com.aizistral.nochatreports.core.ServerSafetyState;
+import com.aizistral.nochatreports.core.SigningMode;
 import com.aizistral.nochatreports.gui.FontHelper;
 import com.terraformersmc.modmenu.api.ConfigScreenFactory;
 import com.terraformersmc.modmenu.api.ModMenuApi;
 import me.shedaniel.clothconfig2.api.ConfigBuilder;
 import me.shedaniel.clothconfig2.api.ConfigCategory;
 import me.shedaniel.clothconfig2.api.ConfigEntryBuilder;
-import me.shedaniel.clothconfig2.gui.entries.StringListListEntry;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.minecraft.client.Minecraft;
@@ -17,6 +17,7 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.HoverEvent;
 
 import java.util.List;
+import java.util.stream.Stream;
 
 /**
  * Implementation of ModMenu and ClothConfig support for the mod.
@@ -51,7 +52,6 @@ public final class ModMenuIntegration implements ModMenuApi {
 			// Set category
 			ConfigCategory client = builder.getOrCreateCategory(Component.translatable("configuration.NoChatReports.category.client"));
 			ConfigCategory lan = builder.getOrCreateCategory(Component.translatable("configuration.NoChatReports.category.lan"));
-			ConfigCategory whitelist = builder.getOrCreateCategory(Component.translatable("configuration.NoChatReports.category.whitelist"));
 
 			ConfigEntryBuilder entryBuilder = builder.entryBuilder();
 
@@ -70,6 +70,16 @@ public final class ModMenuIntegration implements ModMenuApi {
 					.setDefaultValue(true)
 					.setTooltip(this.makeTooltip("option.NoChatReports.showNCRButton.tooltip"))
 					.setSaveConsumer(newValue -> NCRConfig.getClient().showNCRButton = newValue)
+					.build());
+
+			// Dropdown for defaultSigningMode
+			client.addEntry(entryBuilder.startStringDropdownMenu(Component.translatable("option.NoChatReports.defaultSigningMode"), NCRConfig.getClient().defaultSigningMode.toString()
+					)
+					.setDefaultValue(SigningMode.PROMPT.toString())
+					.setTooltip(this.makeTooltip("option.NoChatReports.defaultSigningMode.tooltip"))
+					.setSelections(Stream.of(SigningMode.values()).map(SigningMode::name).toList())
+					.setSaveConsumer(newValue -> NCRConfig.getClient().defaultSigningMode = SigningMode.valueOf(newValue))
+					.setSuggestionMode(false)
 					.build());
 
 			// Set an option for showReloadButton

--- a/src/main/java/com/aizistral/nochatreports/core/SigningMode.java
+++ b/src/main/java/com/aizistral/nochatreports/core/SigningMode.java
@@ -53,18 +53,23 @@ public enum SigningMode {
 	 */
 	NEVER_FORCED;
 
-	public MutableComponent getName() {
-		String key = "gui.nochatreports.signing_mode." + this.name().toLowerCase();
+	public String getNameKey() {
+		return "gui.nochatreports.signing_mode." + this.name().toLowerCase();
+	}
 
+	public MutableComponent getName() {
 		if (this != DEFAULT)
-			return Component.translatable(key);
+			return Component.translatable(this.getNameKey());
 		else
-			return Component.translatable(key, NCRConfig.getClient().defaultSigningMode().getName());
+			return Component.translatable(this.getNameKey(), NCRConfig.getClient().defaultSigningMode().getName());
+	}
+
+	public String getTooltipKey() {
+		return "gui.nochatreports.signing_mode." + this.name().toLowerCase() + ".tooltip";
 	}
 
 	public MutableComponent getTooltip() {
-		return Component.translatable("gui.nochatreports.signing_mode." + this.name().toLowerCase() +
-				".tooltip");
+		return Component.translatable(this.getTooltipKey());
 	}
 
 	public SigningMode next() {
@@ -76,7 +81,7 @@ public enum SigningMode {
 			result = values()[this.ordinal() + 1];
 		}
 
-		return result == NEVER_FORCED ? result.next() : result;
+		return result.isSelectable() ? result : result.next();
 	}
 
 	public SigningMode resolve() {
@@ -85,6 +90,14 @@ public enum SigningMode {
 		case NEVER_FORCED -> NEVER;
 		default -> this;
 		};
+	}
+
+	public boolean isSelectable() {
+		return this != NEVER_FORCED;
+	}
+
+	public boolean isSelectableGlobally() {
+		return this.isSelectable() && this != DEFAULT;
 	}
 
 	public static SigningMode nullable(@Nullable SigningMode mode) {

--- a/src/main/resources/assets/nochatreports/lang/en_us.json
+++ b/src/main/resources/assets/nochatreports/lang/en_us.json
@@ -81,6 +81,8 @@
 	"option.NoChatReports.enableMod.tooltip": "Responsible for enabling most of the mod's client-sided functionality. Will require re-joining the server to take effect if toggled mid-session.",
 	"option.NoChatReports.showNCRButton": "Show NCR button",
 	"option.NoChatReports.showNCRButton.tooltip": "Adds a button that toggles most of the mod's client-sided functionality to multiplayer menu.",
+	"option.NoChatReports.defaultSigningMode": "Default signing mode",
+	"option.NoChatReports.defaultSigningMode.tooltip": "Sets the signing mode default for servers that force or allow chat signing.",
 	"option.NoChatReports.showReloadButton": "Show reload button",
 	"option.NoChatReports.showReloadButton.tooltip": "Adds a button for config reloading to multiplayer menu.",
 	"option.NoChatReports.verifiedIconEnabled": "Verified icon enabled",


### PR DESCRIPTION
Removes the empty whitelist tab and adds a default signing mode dropdown instead.
![image](https://user-images.githubusercontent.com/8611110/206758183-ecdaeb7d-0df4-45f8-8c8e-82716651b322.png)

![Screenshot_20221209_192242](https://user-images.githubusercontent.com/8611110/206758128-b99815c7-cefc-42d1-ae2b-e3f1c94d46ea.png)

Problems:
* NEVER_FORCED is visible
* List entries are not localized (while they probably could be)
* The tooltip is big, though still properly wrapped