### PR TITLE
Fix ServerAddressAdapter for IPv6

### DIFF
--- a/src/main/java/com/aizistral/nochatreports/config/ServerAddressAdapter.java
+++ b/src/main/java/com/aizistral/nochatreports/config/ServerAddressAdapter.java
@@ -1,18 +1,13 @@
 package com.aizistral.nochatreports.config;
 
-import java.io.IOException;
-import java.lang.reflect.Type;
-
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import com.google.gson.InstanceCreator;
 import com.google.gson.TypeAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
-
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.minecraft.client.multiplayer.resolver.ServerAddress;
+
+import java.io.IOException;
 
 @Environment(EnvType.CLIENT)
 public class ServerAddressAdapter extends TypeAdapter<ServerAddress> {
@@ -25,17 +20,16 @@ public class ServerAddressAdapter extends TypeAdapter<ServerAddress> {
 	@Override
 	public ServerAddress read(JsonReader reader) throws IOException {
 		String string = reader.nextString();
-		String address[] = string.split(":");
 
-		if (address.length != 2)
+		if (!ServerAddress.isValidAddress(string))
 			throw new IOException("Incorrect server address format: " + string);
 
-		return new ServerAddress(address[0], Integer.valueOf(address[1]));
+		return ServerAddress.parseString(string);
 	}
 
 	@Override
 	public void write(JsonWriter writer, ServerAddress address) throws IOException {
-		writer.value(address.getHost() + ":" + address.getPort());
+		writer.value(address.toString());
 	}
 
 }


### PR DESCRIPTION
Noticed a bug where IPv6 addresses could not be parsed from config files, which would crash the game on startup.

Implemented a fix which uses the native methods to parse and write `ServerAddress` objects in the `ServerAddressAdapter`.

Also cleaned up unused imports.