### PR TITLE
Add "message" and "reply" as encryptable commands

### DIFF
--- a/src/main/java/com/aizistral/nochatreports/common/config/NCRConfigEncryption.java
+++ b/src/main/java/com/aizistral/nochatreports/common/config/NCRConfigEncryption.java
@@ -14,7 +14,7 @@ public class NCRConfigEncryption extends JSONConfig {
 	protected String encryptionKey = Encryption.AES_CFB8.getDefaultKey(), encryptionPassphrase = "",
 			algorithmName = Encryption.AES_CFB8.getName();
 	protected List<String> encryptableCommands = List.of("msg:1", "w:1", "whisper:1", "tell:1", "r:0", "dm:1",
-			"me:0", "m:1", "t:1", "pm:1", "emsg:1", "epm:1", "etell:1", "ewhisper:1");
+			"me:0", "m:1", "t:1", "pm:1", "emsg:1", "epm:1", "etell:1", "ewhisper:1", "message:1", "reply:0");
 	private transient Encryption algorithm;
 	private transient boolean isValid = false;
 	private transient String lastMessage = "???";


### PR DESCRIPTION
Adds `/message` and `/reply` as encryptable commands, common aliases for `/msg` and `/r` respectively in various plugins. 